### PR TITLE
fix: avoid removal user when having maintainer role

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41585,20 +41585,20 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
         if (input.removeInactive) {
             const inactiveSeatsAssignedIndividually = inactiveSeats.filter(seat => !seat.assigning_team);
             if (inactiveSeatsAssignedIndividually.length > 0) {
-                core.group('Removing inactive seats', () => __awaiter(void 0, void 0, void 0, function* () {
+                yield core.group('Removing inactive seats', () => __awaiter(void 0, void 0, void 0, function* () {
                     const response = yield octokit.request(`DELETE /orgs/{org}/copilot/billing/selected_users`, {
                         org: org,
                         selected_usernames: inactiveSeatsAssignedIndividually.map(seat => seat.assignee.login),
                     });
                     core.info(`Removed ${response.data.seats_cancelled} seats`);
-                    console.log(typeof response.data.seats_cancelled);
                     allRemovedSeatsCount += response.data.seats_cancelled;
+                    core.info(`removed users:  ${inactiveSeatsAssignedIndividually.map(seat => seat.assignee.login)}`);
                 }));
             }
         }
         if (input.removefromTeam) {
             const inactiveSeatsAssignedByTeam = inactiveSeats.filter(seat => seat.assigning_team);
-            core.group('Removing inactive seats from team', () => __awaiter(void 0, void 0, void 0, function* () {
+            yield core.group('Removing inactive seats from team', () => __awaiter(void 0, void 0, void 0, function* () {
                 for (const seat of inactiveSeatsAssignedByTeam) {
                     if (!seat.assigning_team || typeof (seat.assignee.login) !== 'string')
                         continue;
@@ -41607,6 +41607,7 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
                         team_slug: seat.assigning_team.slug,
                         username: seat.assignee.login
                     });
+                    core.info(`${seat.assigning_team.slug} removed from team ${seat.assignee.login}`);
                 }
             }));
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -41602,6 +41602,16 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
                 for (const seat of inactiveSeatsAssignedByTeam) {
                     if (!seat.assigning_team || typeof (seat.assignee.login) !== 'string')
                         continue;
+                    const response = yield octokit.request(`GET /orgs/{org}/teams/{team_slug}/memberships/{username}`, {
+                        org: org,
+                        team_slug: seat.assigning_team.slug,
+                        username: seat.assignee.login
+                    });
+                    core.debug(`User ${seat.assignee.login} has ${response.data.role} role on team ${seat.assigning_team.slug}`);
+                    if (response.data.role === 'maintainer') {
+                        core.info(`User ${seat.assignee.login} is maintainer, skipping removal`);
+                        continue;
+                    }
                     yield octokit.request('DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}', {
                         org: org,
                         team_slug: seat.assigning_team.slug,

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,22 +248,21 @@ const run = async (): Promise<void> => {
     if (input.removeInactive) {
       const inactiveSeatsAssignedIndividually = inactiveSeats.filter(seat => !seat.assigning_team);
       if (inactiveSeatsAssignedIndividually.length > 0) {
-        core.group('Removing inactive seats', async () => {
+        await core.group('Removing inactive seats', async () => {
           const response = await octokit.request(`DELETE /orgs/{org}/copilot/billing/selected_users`, {
             org: org,
             selected_usernames: inactiveSeatsAssignedIndividually.map(seat => seat.assignee.login),
           });
           core.info(`Removed ${response.data.seats_cancelled} seats`);
-          console.log(typeof response.data.seats_cancelled);
           allRemovedSeatsCount += response.data.seats_cancelled;
-          return inactiveSeatsAssignedIndividually.map(seat => seat.assignee.login)
+          core.info(`removed users:  ${inactiveSeatsAssignedIndividually.map(seat => seat.assignee.login)}`)
         });
       }
     }
 
     if (input.removefromTeam) {
       const inactiveSeatsAssignedByTeam = inactiveSeats.filter(seat => seat.assigning_team);
-      core.group('Removing inactive seats from team', async () => {
+      await core.group('Removing inactive seats from team', async () => {
         for (const seat of inactiveSeatsAssignedByTeam) {
           if (!seat.assigning_team || typeof(seat.assignee.login) !== 'string') continue;
           await octokit.request('DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}', {
@@ -271,6 +270,7 @@ const run = async (): Promise<void> => {
             team_slug: seat.assigning_team.slug,
             username: seat.assignee.login
           })
+	  core.info(`${seat.assigning_team.slug} removed from team ${seat.assignee.login}`)
         }
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,12 +265,25 @@ const run = async (): Promise<void> => {
       await core.group('Removing inactive seats from team', async () => {
         for (const seat of inactiveSeatsAssignedByTeam) {
           if (!seat.assigning_team || typeof(seat.assignee.login) !== 'string') continue;
+
+          const response = await octokit.request(`GET /orgs/{org}/teams/{team_slug}/memberships/{username}`, {
+            org: org,
+            team_slug: seat.assigning_team.slug,
+            username: seat.assignee.login
+          });
+          core.debug(`User ${seat.assignee.login} has ${response.data.role} role on team ${seat.assigning_team.slug}`)
+
+          if (response.data.role === 'maintainer'){
+            core.info(`User ${seat.assignee.login} is maintainer, skipping removal`)
+            continue
+          }
+
           await octokit.request('DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}', {
             org: org,
             team_slug: seat.assigning_team.slug,
             username: seat.assignee.login
           })
-	  core.info(`${seat.assigning_team.slug} removed from team ${seat.assignee.login}`)
+	        core.info(`${seat.assignee.login} removed from team ${seat.assigning_team.slug}`)
         }
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,6 +256,7 @@ const run = async (): Promise<void> => {
           core.info(`Removed ${response.data.seats_cancelled} seats`);
           console.log(typeof response.data.seats_cancelled);
           allRemovedSeatsCount += response.data.seats_cancelled;
+          return inactiveSeatsAssignedIndividually.map(seat => seat.assignee.login)
         });
       }
     }


### PR DESCRIPTION
Hi

We met some issue regarding user deletion from team

Especially the behavior to delete users that "do not use copilot so much" but have administration role of copilot in orgs maintaining team users

This pull request aims to forbid deletion from team when the user **maintains** it

It contains other patches to improve logging in actions steps (Github actions core group feature)